### PR TITLE
Transition to structural schema required in 1.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script:
   - npm test
   - docker build --rm -t "quay.io/razee/remoteresources3:${TRAVIS_COMMIT}" .
   - if [ -n "${TRAVIS_TAG}" ]; then docker tag quay.io/razee/remoteresources3:${TRAVIS_COMMIT} quay.io/razee/remoteresources3:${TRAVIS_TAG}; fi
-  - if [ -n "${TRAVIS_TAG}" ]; then npm version --no-git-tag-version "${TRAVIS_TAG}"; fi
+  - if [[ $TRAVIS_TAG =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then npm version --no-git-tag-version "${TRAVIS_TAG}"; fi
   - docker images
   - ./build/process-template.sh kubernetes/RemoteResourceS3/resource.yaml >/tmp/resource.yaml
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,15 +28,6 @@ deploy:
     on:
       tags: true
       condition: ${TRAVIS_TAG} =~ ^[0-9]+\.[0-9]+\.[0-9]+_[0-9]{3}$
-  - provider: releases
-    file: /tmp/resource.yaml
-    skip_cleanup: true
-    draft: true
-    api_key:
-      secure: "${GITHUB_TOKEN}"
-    on:
-      tags: true
-      condition: ${TRAVIS_TAG} =~ ^[0-9]+\.[0-9]+\.[0-9]+_[0-9]{3}$
 
   # Deploy released builds
   - provider: script

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ kubectl apply -f "https://github.com/razee-io/RemoteResourceS3/releases/latest/d
 ### Sample
 
 ```yaml
-apiVersion: "deploy.razee.io/v1alpha1"
+apiVersion: "deploy.razee.io/v1alpha2"
 kind: RemoteResourceS3
 metadata:
   name: <remote_resource_s3_name>

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ metadata:
 spec:
   auth:
     # hmac:
-    #   access_key_id: <key id>
-    #   secret_access_key: <access key>
+    #   accessKeyId: <key id>
+    #   secretAccessKey: <access key>
     iam:
-      response_type: <provider response type>
-      grant_type: <provider grant type>
+      responseType: <provider response type>
+      grantType: <provider grant type>
       url: <iam auth provider>
-      api_key:
+      apiKeyRef:
         valueFrom:
           secretKeyRef:
             name: <name of secret resource>
@@ -53,108 +53,194 @@ spec:
         url: http://<source_repo_url>/<bucket_path>/
 ```
 
-### Required Fields
+### Spec
 
-- `.spec.auth`
-  - type: object
-  - required: oneOf [[hmac](#HMAC), [iam](#IAM)]
-- `.spec.requests`
-  - type: array
-  - items:
-    - type: object
-    - required: [[options](#Options)]
-    - optional: [[optional](#Optional)]
+**Path:** `.spec`
 
-## Features
+**Description:** `spec` is required and **must** include section `requests`.
+You may also include `auth`, to make connecting to S3 easier.
 
-### Auth
+**Schema:**
 
-#### HMAC
+```yaml
+spec:
+  type: object
+  required: [requests]
+  properties:
+    auth:
+      type: object
+      ...
+    requests:
+      type: array
+      ...
+```
 
-`.spec.auth.hmac`
+### Auth: HMAC
 
-Allows you to connect to s3 buckets using an HMAC key/id pair.
+**Path:** `.spec.auth.hmac`
 
-- Schema
-  - type: object
-  - required: [access_key_id, secret_access_key]
-- Required Fields Schema:
-  - `.spec.auth.hmac.access_key_id`
-    - type: string
-    - or
-    - type: object
-      - required: [valueFrom.secretKeyRef.name, valueFrom.secretKeyRef.key]
-      - optional: [valueFrom.secretKeyRef.namespace]
-  - `.spec.auth.hmac.secret_access_key`
-    - type: string
-    - or
-    - type: object
-      - required: [valueFrom.secretKeyRef.name, valueFrom.secretKeyRef.key]
-      - optional: [valueFrom.secretKeyRef.namespace]
+**Description:** Allows you to connect to s3 buckets using an HMAC key/id pair.
 
-#### IAM
+**Schema:**
 
-`.spec.auth.iam`
+```yaml
+hmac:
+  type: object
+  allOf:
+    - oneOf:
+        - required: [accessKeyId]
+        - required: [accessKeyIdRef]
+    - oneOf:
+        - required: [secretAccessKey]
+        - required: [secretAccessKeyRef]
+  properties:
+    accessKeyId:
+      type: string
+    accessKeyIdRef:
+      type: object
+      required: [valueFrom]
+      properties:
+        valueFrom:
+          type: object
+          required: [secretKeyRef]
+          properties:
+            secretKeyRef:
+              type: object
+              required: [name, key]
+              properties:
+                name:
+                  type: string
+                namespace:
+                  type: string
+                key:
+                  type: string
+    secretAccessKey:
+      type: string
+    secretAccessKeyRef:
+      type: object
+      required: [valueFrom]
+      properties:
+        valueFrom:
+          type: object
+          required: [secretKeyRef]
+          properties:
+            secretKeyRef:
+              type: object
+              required: [name, key]
+              properties:
+                name:
+                  type: string
+                namespace:
+                  type: string
+                key:
+                  type: string
+```
 
-Allows you to connect to s3 buckets using an IAM provider and api key.
+### Auth: IAM
 
-- Schema
-  - type: object
-  - required: [response_type, grant_type, url, api_key]
-  - Sample values for [IBM Cloud Object Storage](https://cloud.ibm.com/docs/services/cloud-object-storage/cli?topic=cloud-object-storage-curl)
-    - response_type: "cloud_iam"
-    - grant_type: "urn:ibm:params:oauth:grant-type:apikey"
-    - url: "[https://iam.cloud.ibm.com/identity/token](https://iam.cloud.ibm.com/identity/token)"
-- Required Fields Schema:
-  - `.spec.auth.iam.response_type`
-    - type: string
-  - `.spec.auth.iam.grant_type`
-    - type: string
-  - `.spec.auth.iam.url`
-    - type: string
-  - `.spec.auth.iam.api_key`
-    - type: string
-    - or
-    - type: object
-      - required: [valueFrom.secretKeyRef.name, valueFrom.secretKeyRef.key]
-      - optional: [valueFrom.secretKeyRef.namespace]
+**Path:** `.spec.auth.iam`
 
-### Requests
+**Description:** Allows you to connect to s3 buckets using an IAM provider and
+api key.
 
-#### Options
+**Schema:**
 
-`.spec.requests.options`
+```yaml
+iam:
+  type: object
+  allOf:
+    - required: [responseType, grantType, url]
+    - oneOf:
+        - required: [apiKey]
+        - required: [apiKeyRef]
+  properties:
+    responseType:
+      type: string
+    grantType:
+      type: string
+    url:
+      type: string
+      format: uri
+    apiKey:
+      type: string
+    apiKeyRef:
+      type: object
+      required: [valueFrom]
+      properties:
+        valueFrom:
+          type: object
+          required: [secretKeyRef]
+          properties:
+            secretKeyRef:
+              type: object
+              required: [name, key]
+              properties:
+                name:
+                  type: string
+                namespace:
+                  type: string
+                key:
+                  type: string
+```
 
-All options defined in an options object will be passed as is to the http request.
-This means you can specify things like headers for authentication in this section.
+**Note:**
 
-- Schema:
-  - type: object
-  - required: [url || uri]
-  - optional: [any other other options to be passed along with the request]
+- Sample values for [IBM Cloud Object Storage](https://cloud.ibm.com/docs/services/cloud-object-storage/cli?topic=cloud-object-storage-curl)
+  - response_type: "cloud_iam"
+  - grant_type: "urn:ibm:params:oauth:grant-type:apikey"
+  - url: "[https://iam.cloud.ibm.com/identity/token](https://iam.cloud.ibm.com/identity/token)"
 
-#### Download Directory Contents
+### Request Options
+
+**Path:** `.spec.requests[].options`
+
+**Description:** All options defined in an options object will be passed as-is
+to the http request. This means you can specify things like headers for
+authentication in this section.
+
+**Schema:**
+
+```yaml
+options:
+  type: object
+  oneOf:
+    - required: [url]
+    - required: [uri]
+  properties:
+    url:
+      type: string
+      format: uri
+    uri:
+      type: string
+      format: uri
+```
+
+### Optional Request
+
+**Path:** `.spec.requests[].optional`
+
+**Description:** if download or applying child resource fails, RemoteResource
+will stop execution and report error to `.status`. You can allow execution to
+continue by marking a reference as optional.
+
+**Schema:**
+
+```yaml
+optional:
+  type: boolean
+```
+
+**Default:** `false`
+
+### Download Directory Contents
 
 - If url/uri ends with `/`, we will assume this is an S3 directory and will attempt
 to download all resources in the directory.
-- Every resource within the directory will be downloaded using the `.spec.requests.options`
+- Every resource within the directory will be downloaded using the `.spec.requests[].options`
 provided with the directory url.
 - Path must follow one of:
   - `http://s3.endpoint.com/bucket/path/to/your/resources/`
   - `http://bucket.s3.endpoint.com/path/to/your/resources/`
-
-#### Optional
-
-`.spec.requests.optional`
-
-- DEFAULT: `false`
-  - if download or applying child resource fails, RemoteResource will stop
-  execution and report error to `.status`.
-- `true`
-  - if download or applying child resource fails, RemoteResource will continue
-  processing the rest of the defined requests, and will report a warning to `.status`.
-- Schema:
-  - type: boolean
 
 ### Managed Resource Labels
 

--- a/kubernetes/RemoteResourceS3/resource.yaml
+++ b/kubernetes/RemoteResourceS3/resource.yaml
@@ -88,11 +88,199 @@ items:
           served: true
           # One and only one version must be marked as the storage version.
           storage: false
+          schema:
+            # openAPIV3Schema is the schema for validating custom objects.
+            openAPIV3Schema:
+              type: object
+              required: [spec]
+              properties:
+                spec:
+                  type: object
+                  required: [requests]
+                  properties:
+                    auth:
+                      type: object
+                      oneOf:
+                        - required: [hmac]
+                        - required: [iam]
+                      properties:
+                        hmac:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        iam:
+                          type: object
+                          required: [responseType, grantType, url]
+                          x-kubernetes-preserve-unknown-fields: true
+                          properties:
+                            responseType:
+                              type: string
+                            grantType:
+                              type: string
+                            url:
+                              type: string
+                              format: uri
+                    requests:
+                      type: array
+                      items:
+                        type: object
+                        required: [options]
+                        properties:
+                          optional:
+                            type: boolean
+                          options:
+                            type: object
+                            oneOf:
+                              - required: [url]
+                              - required: [uri]
+                            properties:
+                              url:
+                                type: string
+                                format: uri
+                              uri:
+                                type: string
+                                format: uri
+                              headers:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                status:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
         - name: v1alpha2
           # Each version can be enabled/disabled by Served flag.
           served: true
           # One and only one version must be marked as the storage version.
           storage: true
+          schema:
+            # openAPIV3Schema is the schema for validating custom objects.
+            openAPIV3Schema:
+              type: object
+              required: [spec]
+              properties:
+                spec:
+                  type: object
+                  required: [requests]
+                  properties:
+                    auth:
+                      type: object
+                      oneOf:
+                        - required: [hmac]
+                        - required: [iam]
+                      properties:
+                        hmac:
+                          type: object
+                          # remove when v1alpha1 is depricated
+                          x-kubernetes-preserve-unknown-fields: true
+                          allOf:
+                            - oneOf:
+                                - required: [accessKeyId]
+                                - required: [accessKeyIdRef]
+                            - oneOf:
+                                - required: [secretAccessKey]
+                                - required: [secretAccessKeyRef]
+                          properties:
+                            accessKeyId:
+                              type: string
+                            accessKeyIdRef:
+                              type: object
+                              required: [valueFrom]
+                              properties:
+                                valueFrom:
+                                  type: object
+                                  required: [secretKeyRef]
+                                  properties:
+                                    secretKeyRef:
+                                      type: object
+                                      required: [name, key]
+                                      properties:
+                                        name:
+                                          type: string
+                                        namespace:
+                                          type: string
+                                        key:
+                                          type: string
+                            secretAccessKey:
+                              type: string
+                            secretAccessKeyRef:
+                              type: object
+                              required: [valueFrom]
+                              properties:
+                                valueFrom:
+                                  type: object
+                                  required: [secretKeyRef]
+                                  properties:
+                                    secretKeyRef:
+                                      type: object
+                                      required: [name, key]
+                                      properties:
+                                        name:
+                                          type: string
+                                        namespace:
+                                          type: string
+                                        key:
+                                          type: string
+                        iam:
+                          type: object
+                          # remove when v1alpha1 is depricated
+                          x-kubernetes-preserve-unknown-fields: true
+                          allOf:
+                            - required: [responseType, grantType, url]
+                            - oneOf:
+                                - required: [apiKey]
+                                - required: [apiKeyRef]
+                          properties:
+                            responseType:
+                              type: string
+                            grantType:
+                              type: string
+                            url:
+                              type: string
+                              format: uri
+                            apiKey:
+                              type: string
+                            apiKeyRef:
+                              type: object
+                              required: [valueFrom]
+                              properties:
+                                valueFrom:
+                                  type: object
+                                  required: [secretKeyRef]
+                                  properties:
+                                    secretKeyRef:
+                                      type: object
+                                      required: [name, key]
+                                      properties:
+                                        name:
+                                          type: string
+                                        namespace:
+                                          type: string
+                                        key:
+                                          type: string
+                    requests:
+                      type: array
+                      items:
+                        type: object
+                        required: [options]
+                        properties:
+                          optional:
+                            type: boolean
+                          options:
+                            type: object
+                            oneOf:
+                              - required: [url]
+                              - required: [uri]
+                            properties:
+                              url:
+                                type: string
+                                format: uri
+                              uri:
+                                type: string
+                                format: uri
+                              headers:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                status:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
       # either Namespaced or Cluster
       scope: Namespaced
       names:
@@ -108,130 +296,3 @@ items:
       subresources:
         # status enables the status subresource.
         status: {}
-      validation:
-        # openAPIV3Schema is the schema for validating custom objects.
-        openAPIV3Schema:
-          type: object
-          required: [spec]
-          properties:
-            spec:
-              type: object
-              required: [requests]
-              properties:
-                auth:
-                  type: object
-                  oneOf:
-                    - required: [hmac]
-                    - required: [iam]
-                  properties:
-                    hmac:
-                      type: object
-                      allOf:
-                        - oneOf:
-                            - required: [accessKeyId]
-                            - required: [accessKeyIdRef]
-                        - oneOf:
-                            - required: [secretAccessKey]
-                            - required: [secretAccessKeyRef]
-                      properties:
-                        accessKeyId:
-                          type: string
-                        accessKeyIdRef:
-                          type: object
-                          required: [valueFrom]
-                          properties:
-                            valueFrom:
-                              type: object
-                              required: [secretKeyRef]
-                              properties:
-                                secretKeyRef:
-                                  type: object
-                                  required: [name, key]
-                                  properties:
-                                    name:
-                                      type: string
-                                    namespace:
-                                      type: string
-                                    key:
-                                      type: string
-                        secretAccessKey:
-                          type: string
-                        secretAccessKeyRef:
-                          type: object
-                          required: [valueFrom]
-                          properties:
-                            valueFrom:
-                              type: object
-                              required: [secretKeyRef]
-                              properties:
-                                secretKeyRef:
-                                  type: object
-                                  required: [name, key]
-                                  properties:
-                                    name:
-                                      type: string
-                                    namespace:
-                                      type: string
-                                    key:
-                                      type: string
-                    iam:
-                      type: object
-                      allOf:
-                        - required: [responseType, grantType, url]
-                        - oneOf:
-                            - required: [apiKey]
-                            - required: [apiKeyRef]
-                      properties:
-                        responseType:
-                          type: string
-                        grantType:
-                          type: string
-                        url:
-                          type: string
-                          format: uri
-                        apiKey:
-                          type: string
-                        apiKeyRef:
-                          type: object
-                          required: [valueFrom]
-                          properties:
-                            valueFrom:
-                              type: object
-                              required: [secretKeyRef]
-                              properties:
-                                secretKeyRef:
-                                  type: object
-                                  required: [name, key]
-                                  properties:
-                                    name:
-                                      type: string
-                                    namespace:
-                                      type: string
-                                    key:
-                                      type: string
-                requests:
-                  type: array
-                  items:
-                    type: object
-                    required: [options]
-                    properties:
-                      optional:
-                        type: boolean
-                      options:
-                        type: object
-                        oneOf:
-                          - required: [url]
-                          - required: [uri]
-                        properties:
-                          url:
-                            type: string
-                            format: uri
-                          uri:
-                            type: string
-                            format: uri
-                          headers:
-                            type: object
-                            x-kubernetes-preserve-unknown-fields: true
-            status:
-              type: object
-              x-kubernetes-preserve-unknown-fields: true

--- a/kubernetes/RemoteResourceS3/resource.yaml
+++ b/kubernetes/RemoteResourceS3/resource.yaml
@@ -87,6 +87,11 @@ items:
           # Each version can be enabled/disabled by Served flag.
           served: true
           # One and only one version must be marked as the storage version.
+          storage: false
+        - name: v1alpha2
+          # Each version can be enabled/disabled by Served flag.
+          served: true
+          # One and only one version must be marked as the storage version.
           storage: true
       # either Namespaced or Cluster
       scope: Namespaced
@@ -106,6 +111,8 @@ items:
       validation:
         # openAPIV3Schema is the schema for validating custom objects.
         openAPIV3Schema:
+          type: object
+          required: [spec]
           properties:
             spec:
               type: object
@@ -114,118 +121,111 @@ items:
                 auth:
                   type: object
                   oneOf:
-                  - type: object
-                    required: [hmac]
-                    properties:
-                      hmac:
-                        type: object
-                        required: [access_key_id, secret_access_key]
-                        properties:
-                          access_key_id:
-                            oneOf:
-                            - type: string
-                            - type: object
-                              required: [valueFrom]
+                    - required: [hmac]
+                    - required: [iam]
+                  properties:
+                    hmac:
+                      type: object
+                      allOf:
+                        - oneOf:
+                            - required: [accessKeyId]
+                            - required: [accessKeyIdRef]
+                        - oneOf:
+                            - required: [secretAccessKey]
+                            - required: [secretAccessKeyRef]
+                      properties:
+                        accessKeyId:
+                          type: string
+                        accessKeyIdRef:
+                          type: object
+                          required: [valueFrom]
+                          properties:
+                            valueFrom:
+                              type: object
+                              required: [secretKeyRef]
                               properties:
-                                valueFrom:
+                                secretKeyRef:
                                   type: object
-                                  required: [secretKeyRef]
+                                  required: [name, key]
                                   properties:
-                                    secretKeyRef:
-                                      type: object
-                                      required: [name, key]
-                                      properties:
-                                        name:
-                                          type: string
-                                        key:
-                                          type: string
-                          secret_access_key:
-                            oneOf:
-                            - type: string
-                            - type: object
-                              required: [valueFrom]
+                                    name:
+                                      type: string
+                                    namespace:
+                                      type: string
+                                    key:
+                                      type: string
+                        secretAccessKey:
+                          type: string
+                        secretAccessKeyRef:
+                          type: object
+                          required: [valueFrom]
+                          properties:
+                            valueFrom:
+                              type: object
+                              required: [secretKeyRef]
                               properties:
-                                valueFrom:
+                                secretKeyRef:
                                   type: object
-                                  required: [secretKeyRef]
+                                  required: [name, key]
                                   properties:
-                                    secretKeyRef:
-                                      type: object
-                                      required: [name, key]
-                                      properties:
-                                        name:
-                                          type: string
-                                        key:
-                                          type: string
-                  - type: object
-                    required: [iam]
-                    properties:
-                      iam:
-                        type: object
-                        required: [response_type, grant_type, url, api_key]
-                        properties:
-                          response_type:
-                            type: string
-                          grant_type:
-                            type: string
-                          url:
-                            type: string
-                            format: uri
-                          api_key:
-                            oneOf:
-                            - type: string
-                            - type: object
-                              required: [valueFrom]
+                                    name:
+                                      type: string
+                                    namespace:
+                                      type: string
+                                    key:
+                                      type: string
+                    iam:
+                      type: object
+                      allOf:
+                        - required: [responseType, grantType, url]
+                        - oneOf:
+                            - required: [apiKey]
+                            - required: [apiKeyRef]
+                      properties:
+                        responseType:
+                          type: string
+                        grantType:
+                          type: string
+                        url:
+                          type: string
+                          format: uri
+                        apiKey:
+                          type: string
+                        apiKeyRef:
+                          type: object
+                          required: [valueFrom]
+                          properties:
+                            valueFrom:
+                              type: object
+                              required: [secretKeyRef]
                               properties:
-                                valueFrom:
+                                secretKeyRef:
                                   type: object
-                                  required: [secretKeyRef]
+                                  required: [name, key]
                                   properties:
-                                    secretKeyRef:
-                                      type: object
-                                      required: [name, key]
-                                      properties:
-                                        name:
-                                          type: string
-                                        key:
-                                          type: string
+                                    name:
+                                      type: string
+                                    namespace:
+                                      type: string
+                                    key:
+                                      type: string
                 requests:
                   type: array
                   items:
                     type: object
+                    required: [options]
                     properties:
                       optional:
                         type: boolean
-                    oneOf:
-                    - type: object
-                      required: [options]
-                      properties:
-                        options:
-                          type: object
-                          required: [url]
-                          properties:
-                            url:
-                              type: string
-                              format: uri
-                    - type: object
-                      required: [options]
-                      properties:
-                        options:
-                          type: object
-                          required: [uri]
-                          properties:
-                            uri:
-                              type: string
-                              format: uri
-                    - type: object
-                      required: [url]
-                      properties:
-                        url:
-                          type: string
-                          format: uri
-                    - type: object
-                      required: [uri]
-                      properties:
-                        uri:
-                          type: string
-                          format: uri
+                      options:
+                        type: object
+                        oneOf:
+                          - required: [url]
+                          - required: [uri]
+                        properties:
+                          url:
+                            type: string
+                            format: uri
+                          uri:
+                            type: string
+                            format: uri

--- a/kubernetes/RemoteResourceS3/resource.yaml
+++ b/kubernetes/RemoteResourceS3/resource.yaml
@@ -109,12 +109,12 @@ items:
                           x-kubernetes-preserve-unknown-fields: true
                         iam:
                           type: object
-                          required: [responseType, grantType, url]
+                          required: [response_type, grant_type, url]
                           x-kubernetes-preserve-unknown-fields: true
                           properties:
-                            responseType:
+                            response_type:
                               type: string
-                            grantType:
+                            grant_type:
                               type: string
                             url:
                               type: string

--- a/kubernetes/RemoteResourceS3/resource.yaml
+++ b/kubernetes/RemoteResourceS3/resource.yaml
@@ -229,3 +229,9 @@ items:
                           uri:
                             type: string
                             format: uri
+                          headers:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true

--- a/kubernetes/RemoteResourceS3/resource.yaml
+++ b/kubernetes/RemoteResourceS3/resource.yaml
@@ -109,7 +109,6 @@ items:
                           x-kubernetes-preserve-unknown-fields: true
                         iam:
                           type: object
-                          required: [response_type, grant_type, url]
                           x-kubernetes-preserve-unknown-fields: true
                           properties:
                             response_type:

--- a/package-lock.json
+++ b/package-lock.json
@@ -180,17 +180,24 @@
       }
     },
     "@razee/razeedeploy-core": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@razee/razeedeploy-core/-/razeedeploy-core-0.5.2.tgz",
-      "integrity": "sha512-+GNRyFoRSZUYywqMnTEQGKwWqH1IEDHZmXHqrHacGIDxiISdxQHeVf8THBBkPdA55XEF5w4ffYDUZ/Ko8UKcKA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@razee/razeedeploy-core/-/razeedeploy-core-0.7.0.tgz",
+      "integrity": "sha512-l1x+ySDSlXI1F31X2gM6CuSyp6w8EImvvDq/UfH4ubKXSTAC84vQvgRudLFAvSH4xv8jxVhBuSNVkI72H5INdw==",
       "requires": {
         "bunyan": "^1.8.12",
         "clone": "^2.1.2",
-        "deepmerge": "^4.0.0",
+        "deepmerge": "^4.2.2",
         "fs-extra": "^8.0.1",
         "js-yaml": "^3.13.1",
         "object-hash": "^2.0.0",
         "object-path": "^0.11.4"
+      },
+      "dependencies": {
+        "deepmerge": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+          "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+        }
       }
     },
     "@sindresorhus/is": {
@@ -3681,9 +3688,9 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-hash": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.0.0.tgz",
-      "integrity": "sha512-I7zGBH0rDKwVGeGZpZoFaDhIwvJa3l1CZE+8VchylXbInNiCj7sxxea9P5dTM4ftKR5//nrqxrdeGSTWL2VpBA=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.0.1.tgz",
+      "integrity": "sha512-HgcGMooY4JC2PBt9sdUdJ6PMzpin+YtY3r/7wg0uTifP+HJWW8rammseSEHuyt0UeShI183UGssCJqm1bJR7QA=="
     },
     "object-inspect": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@razee/kubernetes-util": "0.0.7",
-    "@razee/razeedeploy-core": "^0.5.2",
+    "@razee/razeedeploy-core": "^0.7.0",
     "bunyan": "^1.8.12",
     "clone": "^2.1.2",
     "deepmerge": "^4.0.0",

--- a/src/RemoteResourceS3Controller.js
+++ b/src/RemoteResourceS3Controller.js
@@ -210,8 +210,8 @@ module.exports = class RemoteResourceS3Controller extends BaseDownloadController
     let res = await request.post({
       form: {
         apikey: apiKey,
-        response_type: iam.response_type,
-        grant_type: iam.grant_type
+        response_type: iam.responseType || iam.response_type,
+        grant_type: iam.grantType || iam.grant_type
       },
       timeout: 60000,
       url: iam.url,

--- a/src/RemoteResourceS3Controller.js
+++ b/src/RemoteResourceS3Controller.js
@@ -114,20 +114,9 @@ module.exports = class RemoteResourceS3Controller extends BaseDownloadController
     let iam = objectPath.get(this.data, ['object', 'spec', 'auth', 'iam']);
     let options = {};
     if (hmac) {
-      if (typeof hmac.access_key_id == 'object') {
-        let secretName = objectPath.get(hmac, 'access_key_id.valueFrom.secretKeyRef.name');
-        let secretNamespace = objectPath.get(hmac, 'access_key_id.valueFrom.secretKeyRef.namespace', this.namespace);
-        let secretKey = objectPath.get(hmac, 'access_key_id.valueFrom.secretKeyRef.key');
-        hmac.access_key_id = await this._getSecretData(secretName, secretKey, secretNamespace);
-      }
-      objectPath.set(options, 'aws.key', hmac.access_key_id);
-      if (typeof hmac.secret_access_key == 'object') {
-        let secretName = objectPath.get(hmac, 'secret_access_key.valueFrom.secretKeyRef.name');
-        let secretNamespace = objectPath.get(hmac, 'secret_access_key.valueFrom.secretKeyRef.namespace', this.namespace);
-        let secretKey = objectPath.get(hmac, 'secret_access_key.valueFrom.secretKeyRef.key');
-        hmac.secret_access_key = await this._getSecretData(secretName, secretKey, secretNamespace);
-      }
-      objectPath.set(options, 'aws.secret', hmac.secret_access_key);
+      let { accessKeyId, secretAccessKey } = await this._fetchHmacSecrets(hmac);
+      objectPath.set(options, 'aws.key', accessKeyId);
+      objectPath.set(options, 'aws.secret', secretAccessKey);
     } else if (iam) {
       let bearerToken = await this._fetchS3Token(iam);
       objectPath.set(options, 'headers.Authorization', `bearer ${bearerToken}`);
@@ -141,17 +130,83 @@ module.exports = class RemoteResourceS3Controller extends BaseDownloadController
     return await request(opt);
   }
 
+  async _fetchHmacSecrets(hmac) {
+    let akid;
+    let akidAlpha1 = objectPath.get(hmac, 'access_key_id');
+    let akidStr = objectPath.get(hmac, 'accessKeyId');
+    let akidRef = objectPath.get(hmac, 'accessKeyIdRef');
+
+    if (typeof akidAlpha1 == 'string') {
+      akid = akidAlpha1;
+    } else if (typeof akidStr == 'string') {
+      akid = akidStr;
+    } else if (typeof akidAlpha1 == 'object') {
+      let secretName = objectPath.get(akidAlpha1, 'valueFrom.secretKeyRef.name');
+      let secretNamespace = objectPath.get(akidAlpha1, 'valueFrom.secretKeyRef.namespace', this.namespace);
+      let secretKey = objectPath.get(akidAlpha1, 'valueFrom.secretKeyRef.key');
+      akid = await this._getSecretData(secretName, secretKey, secretNamespace);
+    } else if (typeof akidRef == 'object') {
+      let secretName = objectPath.get(akidRef, 'valueFrom.secretKeyRef.name');
+      let secretNamespace = objectPath.get(akidRef, 'valueFrom.secretKeyRef.namespace', this.namespace);
+      let secretKey = objectPath.get(akidRef, 'valueFrom.secretKeyRef.key');
+      akid = await this._getSecretData(secretName, secretKey, secretNamespace);
+    }
+    if (!akid) {
+      throw Error('Must have an access key id when using HMAC');
+    }
+
+    let sak;
+    let sakAlpha1 = objectPath.get(hmac, 'secret_access_key');
+    let sakStr = objectPath.get(hmac, 'secretAccessKey');
+    let sakRef = objectPath.get(hmac, 'secretAccessKeyRef');
+
+    if (typeof sakAlpha1 == 'string') {
+      sak = sakAlpha1;
+    } else if (typeof sakStr == 'string') {
+      sak = sakStr;
+    } else if (typeof sakAlpha1 == 'object') {
+      let secretName = objectPath.get(sakAlpha1, 'valueFrom.secretKeyRef.name');
+      let secretNamespace = objectPath.get(sakAlpha1, 'valueFrom.secretKeyRef.namespace', this.namespace);
+      let secretKey = objectPath.get(sakAlpha1, 'valueFrom.secretKeyRef.key');
+      sak = await this._getSecretData(secretName, secretKey, secretNamespace);
+    } else if (typeof sakRef == 'object') {
+      let secretName = objectPath.get(sakRef, 'valueFrom.secretKeyRef.name');
+      let secretNamespace = objectPath.get(sakRef, 'valueFrom.secretKeyRef.namespace', this.namespace);
+      let secretKey = objectPath.get(sakRef, 'valueFrom.secretKeyRef.key');
+      sak = await this._getSecretData(secretName, secretKey, secretNamespace);
+    }
+    if (!sak) {
+      throw Error('Must have a secret access key when using HMAC');
+    }
+
+    return { accessKeyId: akid, secretAccessKey: sak };
+  }
+
   async _fetchS3Token(iam) {
-    let apiKey = objectPath.get(iam, 'api_key', '');
-    if (typeof apiKey == 'object') {
-      let secretName = objectPath.get(apiKey, 'valueFrom.secretKeyRef.name');
-      let secretNamespace = objectPath.get(apiKey, 'valueFrom.secretKeyRef.namespace', this.namespace);
-      let secretKey = objectPath.get(apiKey, 'valueFrom.secretKeyRef.key');
+    let apiKey;
+    let apiKeyAlpha1 = objectPath.get(iam, 'api_key');
+    let apiKeyStr = objectPath.get(iam, 'apiKey');
+    let apiKeyRef = objectPath.get(iam, 'apiKeyRef');
+
+    if (typeof apiKeyAlpha1 == 'string') {
+      apiKey = apiKeyAlpha1;
+    } else if (typeof apiKeyStr == 'string') {
+      apiKey = apiKeyStr;
+    } else if (typeof apiKeyAlpha1 == 'object') {
+      let secretName = objectPath.get(apiKeyAlpha1, 'valueFrom.secretKeyRef.name');
+      let secretNamespace = objectPath.get(apiKeyAlpha1, 'valueFrom.secretKeyRef.namespace', this.namespace);
+      let secretKey = objectPath.get(apiKeyAlpha1, 'valueFrom.secretKeyRef.key');
+      apiKey = await this._getSecretData(secretName, secretKey, secretNamespace);
+    } else if (typeof apiKeyRef == 'object') {
+      let secretName = objectPath.get(apiKeyRef, 'valueFrom.secretKeyRef.name');
+      let secretNamespace = objectPath.get(apiKeyRef, 'valueFrom.secretKeyRef.namespace', this.namespace);
+      let secretKey = objectPath.get(apiKeyRef, 'valueFrom.secretKeyRef.key');
       apiKey = await this._getSecretData(secretName, secretKey, secretNamespace);
     }
-    if (apiKey == '') {
-      return Promise.reject('Failed to find valid api_key to authenticate against iam');
+    if (!apiKey) {
+      return Promise.reject('Failed to find valid apikey to authenticate against iam');
     }
+
     let res = await request.post({
       form: {
         apikey: apiKey,

--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,7 @@ async function createClassicEventHandler(kc) {
 
 async function createNewEventHandler(kc) {
   let result;
-  let resourceMeta = await kc.getKubeResourceMeta('deploy.razee.io/v1alpha2', ControllerString, 'watch');
+  let resourceMeta = await kc.getKubeResourceMeta('deploy.razee.io/v1alpha1', ControllerString, 'watch');
   if (resourceMeta) {
     const Controller = require(`./${ControllerString}Controller`);
     let params = {
@@ -56,7 +56,7 @@ async function createNewEventHandler(kc) {
     };
     result = new EventHandler(params);
   } else {
-    log.error(`Unable to find KubeResourceMeta for deploy.razee.io/v1alpha2: ${ControllerString}`);
+    log.error(`Unable to find KubeResourceMeta for deploy.razee.io/v1alpha1: ${ControllerString}`);
   }
   return result;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,7 @@ async function createClassicEventHandler(kc) {
 
 async function createNewEventHandler(kc) {
   let result;
-  let resourceMeta = await kc.getKubeResourceMeta('deploy.razee.io/v1alpha1', ControllerString, 'watch');
+  let resourceMeta = await kc.getKubeResourceMeta('deploy.razee.io/v1alpha2', ControllerString, 'watch');
   if (resourceMeta) {
     const Controller = require(`./${ControllerString}Controller`);
     let params = {
@@ -56,7 +56,7 @@ async function createNewEventHandler(kc) {
     };
     result = new EventHandler(params);
   } else {
-    log.error(`Unable to find KubeResourceMeta for deploy.razee.io/v1alpha1: ${ControllerString}`);
+    log.error(`Unable to find KubeResourceMeta for deploy.razee.io/v1alpha2: ${ControllerString}`);
   }
   return result;
 }


### PR DESCRIPTION
Allow for old non structural schema under deploy.razee.io/v1alpha1 and continues support the schema in the code as well as define the new structural schema under deploy.razee.io/v1alpha2 and also understand the new schema in the code.