### PR TITLE
build: binaries for IBM Z (s390x) architecture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -158,5 +158,3 @@ jobs:
          on:
            tags: true
            condition: ${TRAVIS_TAG} =~ ^[0-9]+\.[0-9]+\.[0-9]+$
-
-           

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: node_js
 node_js:
   - "lts/*"
 
+arch:
+  - amd64
+  - s390x
+
 services:
   - docker
 
@@ -13,7 +17,7 @@ env:
 script:
   # Audit npm packages. Fail build whan a PR audit fails, otherwise report the vulnerability and proceed.
   - if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then npm audit; else npm audit || true; fi
-  - npm run lint
+  - if [[ "$TRAVIS_CPU_ARCH" != "s390x" ]]; then npm run lint; else npm run lint-s390x; fi
   - npm test
   - docker build --rm -t "quay.io/razee/remoteresources3:${TRAVIS_COMMIT}" .
   - if [ -n "${TRAVIS_TAG}" ]; then docker tag quay.io/razee/remoteresources3:${TRAVIS_COMMIT} quay.io/razee/remoteresources3:${TRAVIS_TAG}; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -158,4 +158,5 @@ jobs:
          on:
            tags: true
            condition: ${TRAVIS_TAG} =~ ^[0-9]+\.[0-9]+\.[0-9]+$
+
            

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "test:debug": "mocha --inspect-brk",
     "check-coverage": "nyc check-coverage --statements 0 --branches 0 --functions 0 --lines 0",
     "lint": "npx npm-run-all eslint markdownlint yaml-lint jsonlint shellcheck",
-    "lint-s390x": "npx npm-run-all eslint markdownlint yaml-lint jsonlint",
     "eslint": "npx eslint src/",
     "markdownlint": "npx markdownlint README.md docs/",
     "dockerlint": "npx dockerlint Dockerfile",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:debug": "mocha --inspect-brk",
     "check-coverage": "nyc check-coverage --statements 0 --branches 0 --functions 0 --lines 0",
     "lint": "npx npm-run-all eslint markdownlint yaml-lint jsonlint shellcheck",
+    "lint-s390x": "npx npm-run-all eslint markdownlint yaml-lint jsonlint",
     "eslint": "npx eslint src/",
     "markdownlint": "npx markdownlint README.md docs/",
     "dockerlint": "npx dockerlint Dockerfile",


### PR DESCRIPTION
Updated .travis.yml file to build container images for IBM Z (s390x) in Travis CI. Also executing unit tests on s390x. Travis CI jobs for both amd64 and s390x passed on the fork.
![image](https://user-images.githubusercontent.com/21959540/103375294-bb1d4080-4a8e-11eb-82b3-10f64008e576.png)
